### PR TITLE
5.0.13

### DIFF
--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -37,6 +37,18 @@ class Encryption {
     this.encryptor = Encryptor(Object.assign({ key: appKey }, options))
   }
 
+  resetAppKey(appKey, options) {
+    /**
+     * Throw exception when app key doesn't exists.
+     */
+     if (!appKey) {
+      throw GE.RuntimeException.missingAppKey('Encryption')
+    }
+
+    this.appKey = appKey
+    this.encryptor = Encryptor(Object.assign({ key: appKey }, options))
+  }
+
   /**
    * Returns a new instance of encrypter with different options
    *

--- a/src/Encryption/index.js
+++ b/src/Encryption/index.js
@@ -37,7 +37,12 @@ class Encryption {
     this.encryptor = Encryptor(Object.assign({ key: appKey }, options))
   }
 
-  resetAppKey(appKey, options) {
+  /**
+   * @description Sets a new appKey
+   * @param {string} appKey appKey
+   * @param {Object} options Encryptor options
+   */
+   resetAppKey(appKey, options) {
     /**
      * Throw exception when app key doesn't exists.
      */


### PR DESCRIPTION
## Proposed changes

Adds a resetApiKey method for changing the appKey without restarting the app.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-framework/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

Our application requires syncing encrypted data between running deployments. To avoid sending unencrypted data, one solution is to share the appKey. Unfortunately, the appKey is crucial to using our HTTPS certificate, which must - of course - be loaded on boot, meaning an appKey must exist before the sync can occur. This change allows us to create an appKey and encrypt the certificate password; once sync has occurred, the password can be decrypted, the appKey changed, and the password re-encrypted - all without restarting the application or storing unencrypted data.
